### PR TITLE
refactor: replace gofmt private repo dependency with inline check

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: "1.21"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: gofmt

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -13,6 +13,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: gofmt
-        uses: gametimesf/github-actions/go/fmt@v0.6.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULT=$(gofmt -l -d -e .)
+          LINECOUNT=$(echo "$RESULT" | wc -l)
+          if [ $LINECOUNT -eq 1 ]; then 
+            exit 0
+          fi
+          while IFS= read -r LINE; do
+            echo "$LINE"
+          done <<< "$RESULT"
+          exit 1
+          fi

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 /*
 Package braintree is a client library for Braintree.
 
-Initializing
+# Initializing
 
 Initialize it with API Keys:
 
@@ -11,7 +11,7 @@ Initialize it with an Access Token:
 
 	braintree.NewWithAccessToken(accessToken)
 
-Loggers and HTTP Clients
+# Loggers and HTTP Clients
 
 Optionally configure a logger and HTTP client:
 
@@ -19,7 +19,7 @@ Optionally configure a logger and HTTP client:
 	bt.Logger = log.New(...)
 	bt.HttpClient = ...
 
-Creating Transactions
+# Creating Transactions
 
 Create transactions:
 
@@ -30,7 +30,7 @@ Create transactions:
 		PaymentMethodNonce: braintree.FakeNonceTransactable,
 	})
 
-API Errors
+# API Errors
 
 API errors are intended to be consumed in two ways. One, they can be dealt with as a single unit:
 


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

## Feature/bug description

The gofmt pull request check currently uses the gametimesf/github-actions repo's workflow. We want to make that repo private, which means it cannot be used by a public repo. Because this repo is forked, and it's a hassle to convert it to private, I am replacing that dependency with an inline gofmt check instead.

## This is how I decided to implement/fix it

I am replacing the github-actions repo workflow dependency with an inline gofmt check instead.

## JIRA link

https://gametime.atlassian.net/browse/PLT-107

## What does this change affect? (What can this break?)
Describe the critical path(s) affected as well as the related component and system functions.

Could potentially break pull request checks for this repo

## How has this been tested

Tested in this PR
Also tested on [this other PR in testy](https://github.com/gametimesf/testy/pull/27) in which I did the same thing

## Observability

Before opening a PR consider whether you have added sufficient observability, do you need to add any datadog additional metrics or spans?

N/A

- [ ] Do your metrics follow the naming conventions?

### How will this change be monitored

N/A
