### PR TITLE
added oauth gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ braintree.sublime-project
 .env
 .idea
 .vscode
+.DS_Store

--- a/braintree.go
+++ b/braintree.go
@@ -188,6 +188,9 @@ func (g *Braintree) WebhookTesting() *WebhookTestingGateway {
 func (g *Braintree) PaymentMethod() *PaymentMethodGateway {
 	return &PaymentMethodGateway{g}
 }
+func (g *Braintree) Oauth() *OAuthGateway {
+	return &OAuthGateway{g}
+}
 
 func (g *Braintree) PaymentMethodNonce() *PaymentMethodNonceGateway {
 	return &PaymentMethodNonceGateway{g}

--- a/braintree.go
+++ b/braintree.go
@@ -54,7 +54,7 @@ func New(env Environment, merchId, pubKey, privKey string) *Braintree {
 
 // NewWithHttpClient creates a Braintree client with API Keys and a HTTP Client.
 func NewWithHttpClient(env Environment, merchantId, publicKey, privateKey string, client *http.Client) *Braintree {
-	return &Braintree{credentials: newAPIKey(env, merchantId, publicKey, privateKey, "", ""), HttpClient: client}
+	return &Braintree{credentials: newAPIKey(env, merchantId, publicKey, privateKey), HttpClient: client}
 }
 
 // NewV2 creates a Braintree client with API Keys and client credentials.
@@ -65,7 +65,7 @@ func NewV2(env Environment, merchId, pubKey, privKey, clientId, clientSecrets st
 
 // NewWithHttpClient creates a Braintree client with API Keys and a HTTP Client.
 func NewWithHttpClientV2(env Environment, merchantId, publicKey, privateKey, clientId, clientSecret string, client *http.Client) *Braintree {
-	return &Braintree{credentials: newAPIKey(env, merchantId, publicKey, privateKey, clientId, clientSecret), HttpClient: client}
+	return &Braintree{credentials: newAPIKeyV2(env, merchantId, publicKey, privateKey, clientId, clientSecret), HttpClient: client}
 }
 
 // NewWithAccessToken creates a Braintree client with an Access Token.

--- a/braintree.go
+++ b/braintree.go
@@ -18,6 +18,7 @@ type apiVersion int
 const (
 	apiVersion3 apiVersion = 3
 	apiVersion4 apiVersion = 4
+	apiVersion6 apiVersion = 6
 )
 
 const defaultTimeout = time.Second * 60

--- a/braintree.go
+++ b/braintree.go
@@ -57,15 +57,15 @@ func NewWithHttpClient(env Environment, merchantId, publicKey, privateKey string
 	return &Braintree{credentials: newAPIKey(env, merchantId, publicKey, privateKey), HttpClient: client}
 }
 
-// NewV2 creates a Braintree client with API Keys and client credentials.
+// NewWithCredentials creates a Braintree client with API Keys and client credentials.
 // some endpoints require client credentials to be passed in the header.
-func NewV2(env Environment, merchId, pubKey, privKey, clientId, clientSecrets string) *Braintree {
-	return NewWithHttpClientV2(env, merchId, pubKey, privKey, clientId, clientSecrets, defaultClient)
+func NewWithCredentials(env Environment, merchId, pubKey, privKey, clientId, clientSecrets string) *Braintree {
+	return NewHttpClientWithCredentials(env, merchId, pubKey, privKey, clientId, clientSecrets, defaultClient)
 }
 
 // NewWithHttpClient creates a Braintree client with API Keys and a HTTP Client.
-func NewWithHttpClientV2(env Environment, merchantId, publicKey, privateKey, clientId, clientSecret string, client *http.Client) *Braintree {
-	return &Braintree{credentials: newAPIKeyV2(env, merchantId, publicKey, privateKey, clientId, clientSecret), HttpClient: client}
+func NewHttpClientWithCredentials(env Environment, merchantId, publicKey, privateKey, clientId, clientSecret string, client *http.Client) *Braintree {
+	return &Braintree{credentials: newAPIKeyWithCredentials(env, merchantId, publicKey, privateKey, clientId, clientSecret), HttpClient: client}
 }
 
 // NewWithAccessToken creates a Braintree client with an Access Token.

--- a/credentials.go
+++ b/credentials.go
@@ -4,4 +4,5 @@ type credentials interface {
 	Environment() Environment
 	MerchantID() string
 	AuthorizationHeader() string
+	AuthorizationHeaderWithClientCreds() string
 }

--- a/credentials_access_token.go
+++ b/credentials_access_token.go
@@ -39,3 +39,11 @@ func (t accessToken) MerchantID() string {
 func (t accessToken) AuthorizationHeader() string {
 	return "Bearer " + t.raw
 }
+
+// AuthorizationHeaderWithClientCreds is not supported for access tokens
+// and will panic if called. access tokens are not used for client credentials.
+// This method is only implemented to satisfy the credentials interface.
+// use AuthorizationHeader() instead.
+func (t accessToken) AuthorizationHeaderWithClientCreds() string {
+	panic("not implemented")
+}

--- a/credentials_api_key.go
+++ b/credentials_api_key.go
@@ -11,7 +11,16 @@ type apiKey struct {
 	clientId     string
 }
 
-func newAPIKey(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
+func newAPIKey(env Environment, merchantID, publicKey, privateKey string) credentials {
+	return apiKey{
+		env:        env,
+		merchantID: merchantID,
+		publicKey:  publicKey,
+		privateKey: privateKey,
+	}
+}
+
+func newAPIKeyV2(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
 	return apiKey{
 		env:        env,
 		merchantID: merchantID,

--- a/credentials_api_key.go
+++ b/credentials_api_key.go
@@ -3,18 +3,24 @@ package braintree
 import "encoding/base64"
 
 type apiKey struct {
-	env        Environment
-	merchantID string
-	publicKey  string
-	privateKey string
+	env          Environment
+	merchantID   string
+	publicKey    string
+	privateKey   string
+	clientSecret string
+	clientId     string
 }
 
-func newAPIKey(env Environment, merchantID, publicKey, privateKey string) credentials {
+func newAPIKey(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
 	return apiKey{
 		env:        env,
 		merchantID: merchantID,
 		publicKey:  publicKey,
 		privateKey: privateKey,
+
+		// external creds for limited access to our partner external braintree.
+		clientId:     clientId,
+		clientSecret: clientSecret,
 	}
 }
 
@@ -28,5 +34,11 @@ func (k apiKey) MerchantID() string {
 
 func (k apiKey) AuthorizationHeader() string {
 	auth := k.publicKey + ":" + k.privateKey
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+// AuthorizationHeaderV2 uses the client id and client secret for the Authorization header
+func (k apiKey) AuthorizationHeaderWithClientCreds() string {
+	auth := k.clientId + ":" + k.clientSecret
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/credentials_api_key.go
+++ b/credentials_api_key.go
@@ -20,7 +20,7 @@ func newAPIKey(env Environment, merchantID, publicKey, privateKey string) creden
 	}
 }
 
-func newAPIKeyV2(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
+func newAPIKeyWithCredentials(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
 	return apiKey{
 		env:        env,
 		merchantID: merchantID,

--- a/oauth_credentials.go
+++ b/oauth_credentials.go
@@ -1,0 +1,23 @@
+package braintree
+
+import "time"
+
+type OAuthCredentialsResult struct {
+	AccessToken  string    `xml:"access_token"`
+	RefreshToken string    `xml:"refresh_token"`
+	ExpiresAt    time.Time `xml:"expires_at"`
+}
+
+type OAuthCredentials struct {
+	Credentials OAuthCredentialsResult `xml:"credentials"`
+}
+
+type OAuthRevokeResult struct {
+	// I cannot find the type for the success attribute.
+	// It is not in the documentation, it is not in the code.
+	// I seems as long as it is not exist, it is a success.
+	Success interface{} `xml:"success"`
+}
+type OAuthRevokeToken struct {
+	Result OAuthRevokeResult `xml:"result"`
+}

--- a/oauth_credentials.go
+++ b/oauth_credentials.go
@@ -2,22 +2,11 @@ package braintree
 
 import "time"
 
-type OAuthCredentialsResult struct {
-	AccessToken  string    `xml:"access_token"`
-	RefreshToken string    `xml:"refresh_token"`
-	ExpiresAt    time.Time `xml:"expires_at"`
-}
-
 type OAuthCredentials struct {
-	Credentials OAuthCredentialsResult `xml:"credentials"`
-}
-
-type OAuthRevokeResult struct {
-	// I cannot find the type for the success attribute.
-	// It is not in the documentation, it is not in the code.
-	// I seems as long as it is not exist, it is a success.
-	Success interface{} `xml:"success"`
-}
-type OAuthRevokeToken struct {
-	Result OAuthRevokeResult `xml:"result"`
+	XMLName      string    `xml:"credentials"`
+	AccessToken  string    `xml:"access-token"`
+	RefreshToken string    `xml:"refresh-token"`
+	ExpiresAt    time.Time `xml:"expires-at"`
+	TokenType    string    `xml:"token-type"`
+	Scope        string    `xml:"scope"`
 }

--- a/oauth_gateway.go
+++ b/oauth_gateway.go
@@ -1,0 +1,74 @@
+package braintree
+
+import "context"
+
+type OAuthGateway struct {
+	*Braintree
+}
+
+type (
+	OAuthCreateTokenFromCodeCredentials struct {
+		Code string `xml:"code"`
+		// grant-type will be set to "authorization_code"
+		GrantType string `xml:"grant_type"`
+	}
+
+	OAuthCreateTokenFromCodeRequest struct {
+		Credentials OAuthCreateTokenFromCodeCredentials `xml:"credentials"`
+	}
+
+	OAuthCreateTokenFromRefreshTokenCredentials struct {
+		RefreshToken string `xml:"refresh_token"`
+
+		// grant-type will be set to "refresh_token"
+		GrantType string `xml:"grant_type"`
+	}
+
+	OAuthCreateTokenFromRefreshTokenRequest struct {
+		Credentials OAuthCreateTokenFromRefreshTokenCredentials `xml:"credentials"`
+	}
+
+	OAuthRevokeAccessTokenRequest struct {
+		AccessToken string `xml:"token"`
+	}
+)
+
+func (g *OAuthGateway) CreateTokenFromCode(ctx context.Context, request *OAuthCreateTokenFromCodeRequest) (*OAuthCredentials, error) {
+	request.Credentials.GrantType = "authorization_code"
+
+	resp, err := g.executeVersion(ctx, "POST", "oauth/access_tokens", request, apiVersion6)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 201:
+		return resp.oauthCredentials()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+func (g *OAuthGateway) CreateTokenFromRefreshToken(ctx context.Context, request *OAuthCreateTokenFromRefreshTokenRequest) (*OAuthCredentials, error) {
+	request.Credentials.GrantType = "refresh_token"
+
+	resp, err := g.executeVersion(ctx, "POST", "oauth/access_tokens", request, apiVersion6)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 201:
+		return resp.oauthCredentials()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+func (g *OAuthGateway) RevokeAccessToken(ctx context.Context, request *OAuthRevokeAccessTokenRequest) (*OAuthRevokeToken, error) {
+	resp, err := g.executeVersion(ctx, "POST", "oauth/revoke_access_token", request, apiVersion6)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 201:
+		return resp.revokeAccessTokenResponse()
+	}
+	return nil, &invalidResponseError{resp}
+}

--- a/oauth_gateway.go
+++ b/oauth_gateway.go
@@ -1,74 +1,57 @@
 package braintree
 
-import "context"
+import (
+	"context"
+	"encoding/xml"
+)
 
 type OAuthGateway struct {
 	*Braintree
 }
 
 type (
-	OAuthCreateTokenFromCodeCredentials struct {
-		Code string `xml:"code"`
-		// grant-type will be set to "authorization_code"
-		GrantType string `xml:"grant_type"`
-	}
-
 	OAuthCreateTokenFromCodeRequest struct {
-		Credentials OAuthCreateTokenFromCodeCredentials `xml:"credentials"`
+		XMLName   xml.Name `xml:"credentials"`
+		Code      string   `xml:"code"`
+		GrantType string   `xml:"grant_type"`
 	}
 
-	OAuthCreateTokenFromRefreshTokenCredentials struct {
-		RefreshToken string `xml:"refresh_token"`
-
-		// grant-type will be set to "refresh_token"
-		GrantType string `xml:"grant_type"`
-	}
-
-	OAuthCreateTokenFromRefreshTokenRequest struct {
-		Credentials OAuthCreateTokenFromRefreshTokenCredentials `xml:"credentials"`
-	}
-
-	OAuthRevokeAccessTokenRequest struct {
-		AccessToken string `xml:"token"`
+	OAuthRefreshCredentialsRequest struct {
+		XMLName      xml.Name `xml:"credentials"`
+		RefreshToken string   `xml:"refresh_token"`
+		GrantType    string   `xml:"grant_type"`
 	}
 )
 
-func (g *OAuthGateway) CreateTokenFromCode(ctx context.Context, request *OAuthCreateTokenFromCodeRequest) (*OAuthCredentials, error) {
-	request.Credentials.GrantType = "authorization_code"
+// CreateTokenFromCode creates an OAuth credentials from an authorization code.
+func (g *OAuthGateway) CreateTokenFromCode(ctx context.Context, code string) (*OAuthCredentials, error) {
+	req := OAuthCreateTokenFromCodeRequest{Code: code, GrantType: "authorization_code"}
 
-	resp, err := g.executeVersion(ctx, "POST", "oauth/access_tokens", request, apiVersion6)
+	resp, err := g.executeBaseVersion(ctx, "POST", "oauth/access_tokens", &req, apiVersion6)
 	if err != nil {
 		return nil, err
 	}
+
 	switch resp.StatusCode {
-	case 201:
+	case 200:
 		return resp.oauthCredentials()
 	}
+
 	return nil, &invalidResponseError{resp}
 }
 
-func (g *OAuthGateway) CreateTokenFromRefreshToken(ctx context.Context, request *OAuthCreateTokenFromRefreshTokenRequest) (*OAuthCredentials, error) {
-	request.Credentials.GrantType = "refresh_token"
+// CreateTokenFromRefreshToken creates an OAuth credentials from a refresh token.
+func (g *OAuthGateway) CreateTokenFromRefreshToken(ctx context.Context, refreshToken string) (*OAuthCredentials, error) {
+	req := OAuthRefreshCredentialsRequest{RefreshToken: refreshToken, GrantType: "refresh_token"}
 
-	resp, err := g.executeVersion(ctx, "POST", "oauth/access_tokens", request, apiVersion6)
+	resp, err := g.executeBaseVersion(ctx, "POST", "oauth/access_tokens", &req, apiVersion6)
 	if err != nil {
 		return nil, err
 	}
+
 	switch resp.StatusCode {
-	case 201:
+	case 200:
 		return resp.oauthCredentials()
-	}
-	return nil, &invalidResponseError{resp}
-}
-
-func (g *OAuthGateway) RevokeAccessToken(ctx context.Context, request *OAuthRevokeAccessTokenRequest) (*OAuthRevokeToken, error) {
-	resp, err := g.executeVersion(ctx, "POST", "oauth/revoke_access_token", request, apiVersion6)
-	if err != nil {
-		return nil, err
-	}
-	switch resp.StatusCode {
-	case 201:
-		return resp.revokeAccessTokenResponse()
 	}
 	return nil, &invalidResponseError{resp}
 }

--- a/payment_method.go
+++ b/payment_method.go
@@ -6,11 +6,3 @@ type PaymentMethod interface {
 	IsDefault() bool
 	GetImageURL() string
 }
-
-type PaymentMethodMerchantResult struct {
-	Nonce string `xml:"nonce"`
-}
-
-type PaymentMethodMerchantGrant struct {
-	PaymentMethodResult PaymentMethodMerchantResult `xml:"payment_method_nonce"`
-}

--- a/payment_method.go
+++ b/payment_method.go
@@ -6,3 +6,11 @@ type PaymentMethod interface {
 	IsDefault() bool
 	GetImageURL() string
 }
+
+type PaymentMethodMerchantResult struct {
+	Nonce string `xml:"nonce"`
+}
+
+type PaymentMethodMerchantGrant struct {
+	PaymentMethodResult PaymentMethodMerchantResult `xml:"payment_method_nonce"`
+}

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -83,14 +83,14 @@ func (g *PaymentMethodGateway) Delete(ctx context.Context, token string) error {
 	return &invalidResponseError{resp}
 }
 
-func (g *PaymentMethodGateway) Grant(ctx context.Context, req *PaymentMethodGrantRequest) error {
+func (g *PaymentMethodGateway) Grant(ctx context.Context, req *PaymentMethodGrantRequest) (*PaymentMethodMerchantGrant, error) {
 	resp, err := g.executeVersion(ctx, "POST", "payment_methods/grant", req, apiVersion6)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	switch resp.StatusCode {
 	case 201:
-		return nil
+		return resp.grantResponse()
 	}
-	return &invalidResponseError{resp}
+	return nil, &invalidResponseError{resp}
 }

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -25,13 +25,15 @@ type PaymentMethodRequestOptions struct {
 }
 
 type (
-	PaymentMethodGrant struct {
-		SharedPaymentMethodToken string `xml:"shared_payment_method_token"`
-		AllowVaulting            *bool  `xml:"allow_vaulting,omitempty"`
+	PaymentMethodGrantRequest struct {
+		XMLName                  xml.Name `xml:"payment_method"`
+		SharedPaymentMethodToken string   `xml:"shared_payment_method_token"`
+		AllowVaulting            *bool    `xml:"allow_vaulting,omitempty"`
 	}
 
-	PaymentMethodGrantRequest struct {
-		PaymentMethod PaymentMethodGrant `xml:"payment_method"`
+	PaymentMethodMerchantGrant struct {
+		XMLName string `xml:"payment-method-nonce"`
+		Nonce   string `xml:"nonce"`
 	}
 )
 

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -24,6 +24,17 @@ type PaymentMethodRequestOptions struct {
 	VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
 }
 
+type (
+	PaymentMethodGrant struct {
+		SharedPaymentMethodToken string `xml:"shared_payment_method_token"`
+		AllowVaulting            *bool  `xml:"allow_vaulting,omitempty"`
+	}
+
+	PaymentMethodGrantRequest struct {
+		PaymentMethod PaymentMethodGrant `xml:"payment_method"`
+	}
+)
+
 func (g *PaymentMethodGateway) Create(ctx context.Context, paymentMethodRequest *PaymentMethodRequest) (PaymentMethod, error) {
 	resp, err := g.executeVersion(ctx, "POST", "payment_methods", paymentMethodRequest, apiVersion4)
 	if err != nil {
@@ -67,6 +78,18 @@ func (g *PaymentMethodGateway) Delete(ctx context.Context, token string) error {
 	}
 	switch resp.StatusCode {
 	case 200:
+		return nil
+	}
+	return &invalidResponseError{resp}
+}
+
+func (g *PaymentMethodGateway) Grant(ctx context.Context, req *PaymentMethodGrantRequest) error {
+	resp, err := g.executeVersion(ctx, "POST", "payment_methods/grant", req, apiVersion6)
+	if err != nil {
+		return err
+	}
+	switch resp.StatusCode {
+	case 201:
 		return nil
 	}
 	return &invalidResponseError{resp}

--- a/response.go
+++ b/response.go
@@ -68,6 +68,14 @@ func (r *Response) transactionLineItems() (TransactionLineItems, error) {
 	return b, nil
 }
 
+func (r *Response) grantResponse() (*PaymentMethodMerchantGrant, error) {
+	var b PaymentMethodMerchantGrant
+	if err := xml.Unmarshal(r.Body, &b); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
 func (r *Response) paymentMethod() (PaymentMethod, error) {
 	entityName, err := r.entityName()
 	if err != nil {

--- a/response.go
+++ b/response.go
@@ -28,6 +28,22 @@ func (r *Response) entityName() (string, error) {
 	return b.XMLName.Local, nil
 }
 
+func (r *Response) oauthCredentials() (*OAuthCredentials, error) {
+	var n OAuthCredentials
+	if err := xml.Unmarshal(r.Body, &n); err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+func (r *Response) revokeAccessTokenResponse() (*OAuthRevokeToken, error) {
+	var n OAuthRevokeToken
+	if err := xml.Unmarshal(r.Body, &n); err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
 func (r *Response) merchantAccount() (*MerchantAccount, error) {
 	var b MerchantAccount
 	if err := xml.Unmarshal(r.Body, &b); err != nil {

--- a/response.go
+++ b/response.go
@@ -36,14 +36,6 @@ func (r *Response) oauthCredentials() (*OAuthCredentials, error) {
 	return &n, nil
 }
 
-func (r *Response) revokeAccessTokenResponse() (*OAuthRevokeToken, error) {
-	var n OAuthRevokeToken
-	if err := xml.Unmarshal(r.Body, &n); err != nil {
-		return nil, err
-	}
-	return &n, nil
-}
-
 func (r *Response) merchantAccount() (*MerchantAccount, error) {
 	var b MerchantAccount
 	if err := xml.Unmarshal(r.Body, &b); err != nil {


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

### Feature/bug description:

1. added oauth gateway on apiv6 + all required func to handle external merchant token
2. added payment method grant

### JIRA link:
https://gametime.atlassian.net/browse/BE-11621

### What can this break:
braintree (hopefully not)

### How has this been tested:
integration testing

tested refreshing token
![Screenshot 2024-06-17 at 9 17 16 PM](https://github.com/gametimesf/braintree-go/assets/33045122/b808c404-05f5-4d60-838f-9af938e3b81d)

tested grant (using the access token from test 1 above)
![Screenshot 2024-06-17 at 9 50 41 PM](https://github.com/gametimesf/braintree-go/assets/33045122/9e094710-d210-4de2-b32a-b16686111335)




### Sources
https://developer.paypal.com/braintree/docs/guides/extend/oauth/access-tokens/python
https://github.com/braintree/braintree_python/tree/master


