### PR TITLE
BE-11784 - added shared payment method field to transaction request

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -103,31 +103,32 @@ type Transaction struct {
 }
 
 type TransactionRequest struct {
-	XMLName             string                      `xml:"transaction"`
-	CustomerID          string                      `xml:"customer-id,omitempty"`
-	Type                string                      `xml:"type,omitempty"`
-	Amount              *Decimal                    `xml:"amount"`
-	OrderId             string                      `xml:"order-id,omitempty"`
-	PaymentMethodToken  string                      `xml:"payment-method-token,omitempty"`
-	PaymentMethodNonce  string                      `xml:"payment-method-nonce,omitempty"`
-	MerchantAccountId   string                      `xml:"merchant-account-id,omitempty"`
-	PlanId              string                      `xml:"plan-id,omitempty"`
-	CreditCard          *CreditCard                 `xml:"credit-card,omitempty"`
-	Customer            *CustomerRequest            `xml:"customer,omitempty"`
-	BillingAddress      *Address                    `xml:"billing,omitempty"`
-	ShippingAddress     *Address                    `xml:"shipping,omitempty"`
-	TaxAmount           *Decimal                    `xml:"tax-amount,omitempty"`
-	TaxExempt           bool                        `xml:"tax-exempt,omitempty"`
-	DeviceData          string                      `xml:"device-data,omitempty"`
-	Options             *TransactionOptions         `xml:"options,omitempty"`
-	ServiceFeeAmount    *Decimal                    `xml:"service-fee-amount,attr,omitempty"`
-	RiskData            *RiskDataRequest            `xml:"risk-data,omitempty"`
-	Descriptor          *Descriptor                 `xml:"descriptor,omitempty"`
-	Channel             string                      `xml:"channel,omitempty"`
-	CustomFields        customfields.CustomFields   `xml:"custom-fields,omitempty"`
-	PurchaseOrderNumber string                      `xml:"purchase-order-number,omitempty"`
-	TransactionSource   TransactionSource           `xml:"transaction-source,omitempty"`
-	LineItems           TransactionLineItemRequests `xml:"line-items,omitempty"`
+	XMLName                  string                      `xml:"transaction"`
+	CustomerID               string                      `xml:"customer-id,omitempty"`
+	Type                     string                      `xml:"type,omitempty"`
+	Amount                   *Decimal                    `xml:"amount"`
+	OrderId                  string                      `xml:"order-id,omitempty"`
+	SharedPaymentMethodToken string                      `xml:"shared-payment-method-token,omitempty"`
+	PaymentMethodToken       string                      `xml:"payment-method-token,omitempty"`
+	PaymentMethodNonce       string                      `xml:"payment-method-nonce,omitempty"`
+	MerchantAccountId        string                      `xml:"merchant-account-id,omitempty"`
+	PlanId                   string                      `xml:"plan-id,omitempty"`
+	CreditCard               *CreditCard                 `xml:"credit-card,omitempty"`
+	Customer                 *CustomerRequest            `xml:"customer,omitempty"`
+	BillingAddress           *Address                    `xml:"billing,omitempty"`
+	ShippingAddress          *Address                    `xml:"shipping,omitempty"`
+	TaxAmount                *Decimal                    `xml:"tax-amount,omitempty"`
+	TaxExempt                bool                        `xml:"tax-exempt,omitempty"`
+	DeviceData               string                      `xml:"device-data,omitempty"`
+	Options                  *TransactionOptions         `xml:"options,omitempty"`
+	ServiceFeeAmount         *Decimal                    `xml:"service-fee-amount,attr,omitempty"`
+	RiskData                 *RiskDataRequest            `xml:"risk-data,omitempty"`
+	Descriptor               *Descriptor                 `xml:"descriptor,omitempty"`
+	Channel                  string                      `xml:"channel,omitempty"`
+	CustomFields             customfields.CustomFields   `xml:"custom-fields,omitempty"`
+	PurchaseOrderNumber      string                      `xml:"purchase-order-number,omitempty"`
+	TransactionSource        TransactionSource           `xml:"transaction-source,omitempty"`
+	LineItems                TransactionLineItemRequests `xml:"line-items,omitempty"`
 }
 
 type TransactionRefundRequest struct {


### PR DESCRIPTION
I have added the `shared-payment-method-token` field to the transaction to enable external transaction creation.