### PR TITLE
BE-13114 add CreateTransactionRiskContext method

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -140,6 +140,9 @@ func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*R
 		return nil, err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+	// date of first using the recommendation from the official doc
+	req.Header.Set("Braintree-Version", "2025-02-26")
 	req.Header.Set("User-Agent", fmt.Sprintf("Braintree Go %s", LibraryVersion))
 	req.Header.Set("Authorization", g.credentials.AuthorizationHeader())
 

--- a/braintree.go
+++ b/braintree.go
@@ -82,10 +82,9 @@ func NewWithAccessToken(accessToken string) (*Braintree, error) {
 
 // Braintree interacts with the Braintree API.
 type Braintree struct {
-	credentials       credentials
-	Logger            *log.Logger
-	HttpClient        *http.Client
-	graphqlHttpClient *http.Client
+	credentials credentials
+	Logger      *log.Logger
+	HttpClient  *http.Client
 }
 
 // Environment returns the current environment.
@@ -113,10 +112,6 @@ func (g *Braintree) execute(ctx context.Context, method, path string, xmlObj int
 }
 
 func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*Response, error) {
-	if g.graphqlHttpClient == nil {
-		return nil, fmt.Errorf("graphql HTTP client not initialized")
-	}
-
 	var buf bytes.Buffer
 	if jsonObj != nil {
 		jsonBody, err := json.Marshal(jsonObj)
@@ -127,6 +122,11 @@ func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*R
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	httpClient := g.HttpClient
+	if httpClient == nil {
+		httpClient = defaultClient
 	}
 
 	url := g.GraphQLEnvironment().BaseURL() + "/graphql"
@@ -145,7 +145,7 @@ func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*R
 
 	req = req.WithContext(ctx)
 
-	resp, err := g.graphqlHttpClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/braintree.go
+++ b/braintree.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -111,19 +110,7 @@ func (g *Braintree) execute(ctx context.Context, method, path string, xmlObj int
 	return g.executeVersion(ctx, method, path, xmlObj, apiVersion3)
 }
 
-func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*Response, error) {
-	var buf bytes.Buffer
-	if jsonObj != nil {
-		jsonBody, err := json.Marshal(jsonObj)
-		if err != nil {
-			return nil, err
-		}
-		_, err = buf.Write(jsonBody)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func (g *Braintree) graphqlExecute(ctx context.Context, buf *bytes.Buffer) (*Response, error) {
 	httpClient := g.HttpClient
 	if httpClient == nil {
 		httpClient = defaultClient
@@ -131,11 +118,11 @@ func (g *Braintree) graphqlExecute(ctx context.Context, jsonObj interface{}) (*R
 
 	url := g.GraphQLEnvironment().BaseURL() + "/graphql"
 
-	if g.Logger != nil {
+	if g.Logger != nil && buf != nil {
 		g.Logger.Printf("> %s %s\n%s", http.MethodPost, url, buf.String())
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, &buf)
+	req, err := http.NewRequest(http.MethodPost, url, buf)
 	if err != nil {
 		return nil, err
 	}

--- a/credentials.go
+++ b/credentials.go
@@ -2,6 +2,7 @@ package braintree
 
 type credentials interface {
 	Environment() Environment
+	GraphQLEnvironment() Environment
 	MerchantID() string
 	AuthorizationHeader() string
 	AuthorizationHeaderWithClientCreds() string

--- a/credentials_access_token.go
+++ b/credentials_access_token.go
@@ -8,6 +8,7 @@ import (
 type accessToken struct {
 	raw        string
 	env        Environment
+	graphqlEnv Environment
 	merchantID string
 }
 
@@ -20,9 +21,15 @@ func newAccessToken(accessTokenStr string) (credentials, error) {
 	if err != nil {
 		return nil, errors.New("access token is for unsupported environment, " + err.Error())
 	}
+	graphqlEnv, err := GraphQLEnvironmentFromName(parts[1])
+	if err != nil {
+		return nil, errors.New("access token is for unsupported graphQL environment, " + err.Error())
+	}
+
 	t := accessToken{
 		raw:        accessTokenStr,
 		env:        env,
+		graphqlEnv: graphqlEnv,
 		merchantID: parts[2],
 	}
 	return t, nil
@@ -30,6 +37,10 @@ func newAccessToken(accessTokenStr string) (credentials, error) {
 
 func (t accessToken) Environment() Environment {
 	return t.env
+}
+
+func (t accessToken) GraphQLEnvironment() Environment {
+	return t.graphqlEnv
 }
 
 func (t accessToken) MerchantID() string {

--- a/credentials_api_key.go
+++ b/credentials_api_key.go
@@ -4,6 +4,7 @@ import "encoding/base64"
 
 type apiKey struct {
 	env          Environment
+	graphqlEnv   Environment
 	merchantID   string
 	publicKey    string
 	privateKey   string
@@ -11,18 +12,20 @@ type apiKey struct {
 	clientId     string
 }
 
-func newAPIKey(env Environment, merchantID, publicKey, privateKey string) credentials {
+func newAPIKey(env, graphqlEnv Environment, merchantID, publicKey, privateKey string) credentials {
 	return apiKey{
 		env:        env,
+		graphqlEnv: graphqlEnv,
 		merchantID: merchantID,
 		publicKey:  publicKey,
 		privateKey: privateKey,
 	}
 }
 
-func newAPIKeyWithCredentials(env Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
+func newAPIKeyWithCredentials(env, graphqlEnv Environment, merchantID, publicKey, privateKey, clientId, clientSecret string) credentials {
 	return apiKey{
 		env:        env,
+		graphqlEnv: graphqlEnv,
 		merchantID: merchantID,
 		publicKey:  publicKey,
 		privateKey: privateKey,
@@ -35,6 +38,10 @@ func newAPIKeyWithCredentials(env Environment, merchantID, publicKey, privateKey
 
 func (k apiKey) Environment() Environment {
 	return k.env
+}
+
+func (k apiKey) GraphQLEnvironment() Environment {
+	return k.graphqlEnv
 }
 
 func (k apiKey) MerchantID() string {

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -13,7 +13,7 @@ func TestCredentials(t *testing.T) {
 		ExpectedAuthorizationHeader string
 	}{
 		{
-			newAPIKey(Development, "development_merchant_id", "integration_public_key", "integration_private_key"),
+			newAPIKey(Development, GraphQLDevelopment, "development_merchant_id", "integration_public_key", "integration_private_key"),
 			Development,
 			"development_merchant_id",
 			"Basic aW50ZWdyYXRpb25fcHVibGljX2tleTppbnRlZ3JhdGlvbl9wcml2YXRlX2tleQ==",

--- a/environment.go
+++ b/environment.go
@@ -18,6 +18,10 @@ var (
 	Development = NewEnvironment("http://localhost:3000")
 	Sandbox     = NewEnvironment("https://api.sandbox.braintreegateway.com:443")
 	Production  = NewEnvironment("https://api.braintreegateway.com:443")
+
+	GraphQLDevelopment = NewEnvironment("http://localhost:3000")
+	GraphQLSandbox     = NewEnvironment("https://payments.sandbox.braintree-api.com")
+	GraphQLProduction  = NewEnvironment("https://payments.braintree-api.com")
 )
 
 func EnvironmentFromName(name string) (Environment, error) {
@@ -28,6 +32,18 @@ func EnvironmentFromName(name string) (Environment, error) {
 		return Sandbox, nil
 	case "production":
 		return Production, nil
+	}
+	return Environment{}, fmt.Errorf("unknown environment %q", name)
+}
+
+func GraphQLEnvironmentFromName(name string) (Environment, error) {
+	switch name {
+	case "development":
+		return GraphQLDevelopment, nil
+	case "sandbox":
+		return GraphQLSandbox, nil
+	case "production":
+		return GraphQLProduction, nil
 	}
 	return Environment{}, fmt.Errorf("unknown environment %q", name)
 }

--- a/examples/subscription/server.go
+++ b/examples/subscription/server.go
@@ -30,6 +30,7 @@ import (
 func main() {
 	bt := braintree.New(
 		braintree.Sandbox,
+		braintree.GraphQLSandbox,
 		os.Getenv("BRAINTREE_MERCH_ID"),
 		os.Getenv("BRAINTREE_PUB_KEY"),
 		os.Getenv("BRAINTREE_PRIV_KEY"),

--- a/examples/transaction/server.go
+++ b/examples/transaction/server.go
@@ -44,6 +44,7 @@ func createTransaction(w http.ResponseWriter, r *http.Request) {
 
 	bt := braintree.New(
 		braintree.Sandbox,
+		braintree.GraphQLSandbox,
 		os.Getenv("BRAINTREE_MERCH_ID"),
 		os.Getenv("BRAINTREE_PUB_KEY"),
 		os.Getenv("BRAINTREE_PRIV_KEY"),

--- a/examples/transaction_3ds/server.go
+++ b/examples/transaction_3ds/server.go
@@ -25,6 +25,7 @@ import (
 func getBT() *braintree.Braintree {
 	bt := braintree.New(
 		braintree.Sandbox,
+		braintree.GraphQLSandbox,
 		os.Getenv("BRAINTREE_MERCH_ID"),
 		os.Getenv("BRAINTREE_PUB_KEY"),
 		os.Getenv("BRAINTREE_PRIV_KEY"),

--- a/init_test.go
+++ b/init_test.go
@@ -74,6 +74,7 @@ func init() {
 
 	testGateway = New(
 		Sandbox,
+		GraphQLSandbox,
 		os.Getenv("BRAINTREE_MERCH_ID"),
 		os.Getenv("BRAINTREE_PUB_KEY"),
 		os.Getenv("BRAINTREE_PRIV_KEY"),

--- a/testing_integration_test.go
+++ b/testing_integration_test.go
@@ -30,7 +30,7 @@ func TestSettleTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prodGateway := New(Production, "my_merchant_id", "my_public_key", "my_private_key")
+	prodGateway := New(Production, GraphQLProduction, "my_merchant_id", "my_public_key", "my_private_key")
 
 	_, err = prodGateway.Testing().Settle(ctx, txn.Id)
 	if err.Error() != "Operation not allowed in production environment" {
@@ -68,7 +68,7 @@ func TestSettlementConfirmTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prodGateway := New(Production, "my_merchant_id", "my_public_key", "my_private_key")
+	prodGateway := New(Production, GraphQLProduction, "my_merchant_id", "my_public_key", "my_private_key")
 
 	_, err = prodGateway.Testing().SettlementConfirm(ctx, txn.Id)
 	if err.Error() != "Operation not allowed in production environment" {
@@ -106,7 +106,7 @@ func TestSettlementDeclinedTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prodGateway := New(Production, "my_merchant_id", "my_public_key", "my_private_key")
+	prodGateway := New(Production, GraphQLProduction, "my_merchant_id", "my_public_key", "my_private_key")
 
 	_, err = prodGateway.Testing().SettlementDecline(ctx, txn.Id)
 	if err.Error() != "Operation not allowed in production environment" {
@@ -144,7 +144,7 @@ func TestSettlementPendingTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prodGateway := New(Production, "my_merchant_id", "my_public_key", "my_private_key")
+	prodGateway := New(Production, GraphQLProduction, "my_merchant_id", "my_public_key", "my_private_key")
 
 	_, err = prodGateway.Testing().SettlementPending(ctx, txn.Id)
 	if err.Error() != "Operation not allowed in production environment" {

--- a/transaction.go
+++ b/transaction.go
@@ -223,7 +223,8 @@ type Field struct {
 }
 
 type GraphQLRawResponse[T any] struct {
-	Data map[string]T `json:"data"`
+	Data   map[string]T `json:"data"`
+	Errors interface{}  `json:"errors"`
 }
 
 type CreateTransactionRiskContextResult struct {

--- a/transaction.go
+++ b/transaction.go
@@ -228,6 +228,7 @@ type GraphQLRawResponse[T any] struct {
 }
 
 type CreateTransactionRiskContextResult struct {
+	RawBody          string `json:"raw_body"`
 	ClientMetadataId string `json:"clientMetadataId"`
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -223,12 +223,37 @@ type Field struct {
 }
 
 type GraphQLRawResponse[T any] struct {
-	Data   map[string]T `json:"data"`
-	Errors interface{}  `json:"errors"`
+	Extensions struct {
+		RequestID string `json:"requestId"`
+	} `json:"extensions"`
+	Data   map[string]T   `json:"data"`
+	Errors []GraphQLError `json:"errors"`
+}
+
+type GraphQLError struct {
+	Message   string `json:"message"`
+	Locations []struct {
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	} `json:"locations"`
+	Path       []string `json:"path"`
+	Extensions struct {
+		ErrorClass string   `json:"errorClass"`
+		ErrorType  string   `json:"errorType"`
+		InputPath  []string `json:"inputPath"`
+		LegacyCode string   `json:"legacyCode"`
+	} `json:"extensions"`
+}
+
+func (g *GraphQLError) Error() string {
+	return fmt.Sprintf(
+		"%s[%s] %s: (%s)",
+		g.Extensions.ErrorClass,
+		g.Extensions.ErrorType,
+		g.Message, g.Extensions.LegacyCode)
 }
 
 type CreateTransactionRiskContextResult struct {
-	RawBody          string `json:"raw_body"`
 	ClientMetadataId string `json:"clientMetadataId"`
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -53,9 +53,9 @@ const (
 	PaymentInstrumentTypeVisaCheckoutCard PaymentInstrumentType = "visa_checkout_card"
 )
 
-type graphQLMethod string
+type GraphQLMethod string
 
-const createTransactionRiskContext graphQLMethod = "createTransactionRiskContext"
+const CreateTransactionRiskContext GraphQLMethod = "createTransactionRiskContext"
 
 type DeliveryMethod string
 
@@ -175,11 +175,15 @@ type CreateTransactionRiskContextRequest struct {
 	CustomIntDataOne int `json:"cd_int_one"`
 }
 
+func (c *CreateTransactionRiskContextRequest) GraphQLMethod() GraphQLMethod {
+	return CreateTransactionRiskContext
+}
+
 func (c *CreateTransactionRiskContextRequest) GraphQLRequest() *GraphQLRequest {
 	return &GraphQLRequest{
 		Query: fmt.Sprintf(
 			"mutation ($input: CreateTransactionRiskContextInput!) {%s(input: $input) { clientMetadataId }}",
-			createTransactionRiskContext),
+			c.GraphQLMethod()),
 		Variables: map[string]interface{}{
 			"input": map[string]interface{}{
 				"riskContext": map[string]interface{}{

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -231,8 +231,7 @@ func (g *TransactionGateway) SearchPage(ctx context.Context, query *SearchQuery,
 func (g *TransactionGateway) CreateTransactionRiskContext(
 	ctx context.Context,
 	req *CreateTransactionRiskContextRequest,
-) (*CreateTransactionRiskContextResult, error) {
-
+) (*GraphQLRawResponse[CreateTransactionRiskContextResult], error) {
 	keyName := "createTransactionRiskContext"
 	q := map[string]interface{}{
 		"query": fmt.Sprintf(
@@ -254,13 +253,12 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 	if err != nil {
 		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))
 	}
-	m, ok := res.Data[keyName]
+	_, ok := res.Data[keyName]
 	if !ok {
 		return nil, fmt.Errorf("response does not contain %s data", keyName)
 	}
-	m.RawBody = string(resp.Body)
 
-	return &m, nil
+	return &res, nil
 
 }
 

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -250,7 +250,7 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 	var res GraphQLRawResponse[CreateTransactionRiskContextResult]
 	err = json.Unmarshal(resp.Body, &res)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))
 	}
 
 	m, ok := res.Data[keyName]

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"html"
 )
 
 type TransactionGateway struct {
@@ -248,6 +249,7 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 	}
 
 	var res GraphQLRawResponse[CreateTransactionRiskContextResult]
+	resp.Body = []byte(html.UnescapeString(string(resp.Body)))
 	err = json.Unmarshal(resp.Body, &res)
 	if err != nil {
 		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -234,7 +234,7 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 ) (*GraphQLResponse[CreateTransactionRiskContextResult], error) {
 	reqBody, err := req.GraphQLRequest().Buffer()
 	if err != nil {
-		return nil, fmt.Errorf("can't create request body (%s): %w", createTransactionRiskContext, err)
+		return nil, fmt.Errorf("can't create request body (%s): %w", req.GraphQLMethod(), err)
 	}
 
 	resp, err := g.graphqlExecute(ctx, reqBody)
@@ -249,9 +249,9 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 	if err != nil {
 		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))
 	}
-	_, ok := res.Data[string(createTransactionRiskContext)]
+	_, ok := res.Data[string(req.GraphQLMethod())]
 	if !ok {
-		return nil, fmt.Errorf("response does not contain %s data", createTransactionRiskContext)
+		return nil, fmt.Errorf("response does not contain %s data", req.GraphQLMethod())
 	}
 
 	return &res, nil

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -238,7 +238,7 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 			"mutation ($input: CreateTransactionRiskContextInput!) {%s(input: $input) { clientMetadataId }}",
 			keyName),
 		"variables": map[string]interface{}{
-			"input": req,
+			"input": req.Request(),
 		},
 	}
 

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -254,11 +254,11 @@ func (g *TransactionGateway) CreateTransactionRiskContext(
 	if err != nil {
 		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))
 	}
-
 	m, ok := res.Data[keyName]
 	if !ok {
 		return nil, fmt.Errorf("response does not contain %s data", keyName)
 	}
+	m.RawBody = string(resp.Body)
 
 	return &m, nil
 

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -2,6 +2,7 @@ package braintree
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 )
@@ -224,6 +225,41 @@ func (g *TransactionGateway) SearchPage(ctx context.Context, query *SearchQuery,
 	}
 
 	return pageResult, err
+}
+
+func (g *TransactionGateway) CreateTransactionRiskContext(
+	ctx context.Context,
+	req *CreateTransactionRiskContextRequest,
+) (*CreateTransactionRiskContextResult, error) {
+
+	keyName := "createTransactionRiskContext"
+	q := map[string]interface{}{
+		"query": fmt.Sprintf(
+			"mutation ($input: CreateTransactionRiskContextInput!) {%s(input: $input) { clientMetadataId }}",
+			keyName),
+		"variables": map[string]interface{}{
+			"input": req,
+		},
+	}
+
+	resp, err := g.graphqlExecute(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var res GraphQLRawResponse[CreateTransactionRiskContextResult]
+	err = json.Unmarshal(resp.Body, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	m, ok := res.Data[keyName]
+	if !ok {
+		return nil, fmt.Errorf("response does not contain %s data", keyName)
+	}
+
+	return &m, nil
+
 }
 
 // Search finds transactions matching the search query, returning the first

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -231,31 +231,27 @@ func (g *TransactionGateway) SearchPage(ctx context.Context, query *SearchQuery,
 func (g *TransactionGateway) CreateTransactionRiskContext(
 	ctx context.Context,
 	req *CreateTransactionRiskContextRequest,
-) (*GraphQLRawResponse[CreateTransactionRiskContextResult], error) {
-	keyName := "createTransactionRiskContext"
-	q := map[string]interface{}{
-		"query": fmt.Sprintf(
-			"mutation ($input: CreateTransactionRiskContextInput!) {%s(input: $input) { clientMetadataId }}",
-			keyName),
-		"variables": map[string]interface{}{
-			"input": req.Request(),
-		},
+) (*GraphQLResponse[CreateTransactionRiskContextResult], error) {
+	reqBody, err := req.GraphQLRequest().Buffer()
+	if err != nil {
+		return nil, fmt.Errorf("can't create request body (%s): %w", createTransactionRiskContext, err)
 	}
 
-	resp, err := g.graphqlExecute(ctx, q)
+	resp, err := g.graphqlExecute(ctx, reqBody)
 	if err != nil {
 		return nil, err
 	}
 
-	var res GraphQLRawResponse[CreateTransactionRiskContextResult]
+	var res GraphQLResponse[CreateTransactionRiskContextResult]
+	//cleaning up unsupported characters
 	resp.Body = []byte(html.UnescapeString(string(resp.Body)))
 	err = json.Unmarshal(resp.Body, &res)
 	if err != nil {
 		return nil, fmt.Errorf("can't unmarshal CreateTransactionRiskContextResult: %w, body: %s", err, string(resp.Body))
 	}
-	_, ok := res.Data[keyName]
+	_, ok := res.Data[string(createTransactionRiskContext)]
 	if !ok {
-		return nil, fmt.Errorf("response does not contain %s data", keyName)
+		return nil, fmt.Errorf("response does not contain %s data", createTransactionRiskContext)
 	}
 
 	return &res, nil

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,33 @@
+package braintree
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCreateTransactionRiskContextRequest(t *testing.T) {
+	tmp := CreateTransactionRiskContextRequest{}
+	emptyBody := `{"riskContext":{"fields":[]}}`
+
+	bts, err := json.Marshal(tmp.Request())
+	if err != nil {
+		t.Fatalf("process of build request is not success")
+	}
+	if emptyBody != string(bts) {
+		t.Fatalf("process of build request is not compare")
+	}
+
+	tmp.SenderCreatedDate = time.Now().String()
+	body := fmt.Sprintf(
+		"{\"riskContext\":{\"fields\":[{\"name\":\"sender_create_date\",\"value\":\"%s\"}]}}",
+		tmp.SenderCreatedDate)
+	bts, err = json.Marshal(tmp.Request())
+	if err != nil {
+		t.Fatalf("process of build request is not success")
+	}
+	if body != string(bts) {
+		t.Fatalf("process of build request is not compare, req=%s", string(bts))
+	}
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,7 +1,6 @@
 package braintree
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -9,25 +8,27 @@ import (
 
 func TestCreateTransactionRiskContextRequest(t *testing.T) {
 	tmp := CreateTransactionRiskContextRequest{}
-	emptyBody := `{"riskContext":{"fields":[]}}`
+	emptyBody := `{"query":"mutation ($input: CreateTransactionRiskContextInput!) {createTransactionRiskContext(input: $input) { clientMetadataId }}","variables":{"input":{"riskContext":{"fields":[]}}}}`
 
-	bts, err := json.Marshal(tmp.Request())
+	bts, err := tmp.GraphQLRequest().Buffer()
 	if err != nil {
 		t.Fatalf("process of build request is not success")
 	}
-	if emptyBody != string(bts) {
-		t.Fatalf("process of build request is not compare")
+	if emptyBody != bts.String() {
+		t.Fatalf("process of build request is not compare, %s", bts.String())
 	}
 
 	tmp.SenderCreatedDate = time.Now().String()
 	body := fmt.Sprintf(
-		"{\"riskContext\":{\"fields\":[{\"name\":\"sender_create_date\",\"value\":\"%s\"}]}}",
-		tmp.SenderCreatedDate)
-	bts, err = json.Marshal(tmp.Request())
+		`{"query":"mutation ($input: CreateTransactionRiskContextInput!) {createTransactionRiskContext(input: $input) { clientMetadataId }}","variables":{"input":{"riskContext":{"fields":[{"name":"sender_create_date","value":"%s"}]}}}}`,
+		tmp.SenderCreatedDate,
+	)
+
+	bts, err = tmp.GraphQLRequest().Buffer()
 	if err != nil {
 		t.Fatalf("process of build request is not success")
 	}
-	if body != string(bts) {
-		t.Fatalf("process of build request is not compare, req=%s", string(bts))
+	if body != bts.String() {
+		t.Fatalf("process of build request is not compare, req=%s", bts.String())
 	}
 }

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -14,7 +14,7 @@ import (
 func TestWebhookParseRequest(t *testing.T) {
 	t.Parallel()
 
-	gateway := New(Sandbox, "mid", "sz9g7zhxz8838v7h", "0c809a2d2e8f4e4c817900ff441c9554")
+	gateway := New(Sandbox, GraphQLSandbox, "mid", "sz9g7zhxz8838v7h", "0c809a2d2e8f4e4c817900ff441c9554")
 	webhookGateway := gateway.WebhookNotification()
 
 	body := strings.NewReader("bt_signature=sz9g7zhxz8838v7h%7C4b532339b3107eae876d7637d59217858f320098&bt_payload=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm%0AaWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5%0AcGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI2VDA3OjEyOjI0WjwvdGltZXN0YW1w%0APgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8%0AL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24%2BCg%3D%3D%0A")


### PR DESCRIPTION
Hello, I would like to make Gametime a better place by contributing the following code:

### Feature/bug description:
There are additional conditions for sending transactions that must include additional attributes. To satisfy these conditions, it became necessary to extend the API with support for a new communication channel graphQL. This method accepts a list of required values ​​and returns the meta client identifier that must be added to the transaction in the future

### This is how I decided to implement/fix it:
The implementation is based on the documentation and example of working with GraphQL, the documentation is added in the ticket

### JIRA link:
[BE-13114 Send CreateTransactionRiskContext calls to braintree for transactions](https://gametime.atlassian.net/browse/BE-13114)

### What can this break:
The Braintree client initialization interface has changed, and a new parameter has been added to indicate the environment in which GraphQL will be used.
The new method CreateTransactionRiskContext works separately does not create additional dependencies on existing methods and simply expands the list of possible actions.

### How has this been tested:
For testing, a patched version of the client (current) was used and run on a test environment, with fake input data for testing.
Example:

>    go func() {
> 		log.Logger.Info().Msg("braintree CreateTransactionRiskContext start")
> 		c := context.Background()
> 		resp, err := s.api.Transaction().CreateTransactionRiskContext(c, &braintree.CreateTransactionRiskContextRequest{
> 			SenderAccountId:   req.CustomerID,
> 			SenderFirstName:   req.BillingAddress.FirstName,
> 			SenderLastName:    req.BillingAddress.LastName,
> 			SenderEmail:       "testmail_mock@gmail.loc",
> 			SenderPhone:       "(402) 555 5555",
> 			SenderCountryCode: "US",
> 			SenderCreatedDate: time.Now().Format(time.RFC3339),
> 			DeliveryMethod:    "email",
> 		})
> 		if err != nil {
> 			log.Logger.Error().Err(err).Msg("braintree CreateTransactionRiskContext response error")
> 			return
> 		}
> 		if resp != nil && len(resp.Errors) > 0 {
> 			log.Logger.Error().Interface("transactionRiskContext", resp).Msg("braintree CreateTransactionRiskContext response error")
> 			return
> 		}
> 		log.Logger.Info().Interface("transactionRiskContext", resp).Msg("braintree CreateTransactionRiskContext success")
> 	}()

Logs from testing environment [Link](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~'2025-02-28T21*3a00*3a00.000Z~start~'2025-02-27T20*3a15*3a24.471Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20*40message*20*7e*3d*20*22CreateTransactionRiskContext*22*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000~queryId~'693b53ac-165b-41e2-ad6b-8ed84b48aedb~source~(~'testing-cashregister-service)~lang~'CWLI))

Example of  logs:
_Error result:_
`{"errors":[{"message":"Account is not currently set up for sending risk context data.","locations":[{"line":1,"column":56}],"path":["createTransactionRiskContext"],"extensions":{"errorClass":"VALIDATION","errorType":"user_error","inputPath":["input","riskContext"],"legacyCode":"97001"}}],"data":{"createTransactionRiskContext":null},"extensions":{"requestId":"fa9b9bb6-688f-4fd0-9708-253f39b9b7a9"}}`

_Success result:_
`{"extensions":{"requestId":"7c3e9488-a7ab-4e5c-bdc2-3310887909b4"},"data":{"createTransactionRiskContext":{"clientMetadataId":"edc0221565d3e452782de4e8dfa2324b"}},"errors":null}`

